### PR TITLE
neural network visualization PR

### DIFF
--- a/Backend/Machine Learning/Networks/network.cpp
+++ b/Backend/Machine Learning/Networks/network.cpp
@@ -284,7 +284,8 @@ void glades::NNetwork::run(DataInput* newDataInput, const Terminator* Arnold, in
 
 						cData->set(layerSizes);
 						cData->setArgList(argData);
-					} else 
+					} 
+					else 
 					{
 					    cData->set(cNodeActivations);
 					    cData->setArgList(argData);
@@ -442,8 +443,6 @@ void glades::NNetwork::ForwardPass(unsigned int inputRowCounter,
 		int cInputLayerCounter, int cOutputLayerCounter,
 		unsigned int cInputNodeCounter, unsigned int cOutputNodeCounter)
 {
-    
-
 	for(unsigned int cLayerCounter = 0; cLayerCounter < skeleton->numHiddenLayers()+1; ++cLayerCounter)
 	{
 	    cInputLayerCounter = cLayerCounter;
@@ -473,7 +472,6 @@ void glades::NNetwork::ForwardPass(unsigned int inputRowCounter,
 			    netState->cOutputNode->setActivation(cInputNodeCounter, cEdgeActivation);
 		    }
 		    // Last Input Node for the Output Node
-
 		    float cOutputLayerActivation = 0.0f;
 		    if (netState->lastValidInputNode)
 		    {
@@ -493,7 +491,6 @@ void glades::NNetwork::ForwardPass(unsigned int inputRowCounter,
 			    float cActivationParam = skeleton->getActivationParam(cInputLayerCounter);
 			    cOutputLayerActivation =
 				    GMath::squash(cOutputNodeActivation, cActivationFx, cActivationParam);
-
 
 			    //We add the current node activation to the list of activations that will be sent on the network for visualization purposes
 			    if(inputRowCounter == di->getTrainSize()-1)

--- a/Backend/Machine Learning/Networks/network.cpp
+++ b/Backend/Machine Learning/Networks/network.cpp
@@ -276,6 +276,7 @@ void glades::NNetwork::run(DataInput* newDataInput, const Terminator* Arnold, in
 					if(!firstRunActivation)
 					{
 						firstRunActivation = true;
+						//TODO: Create in header file
 						shmea::GList layerSizes;
 						for(unsigned int cLayerCounter = 0; cLayerCounter < skeleton->numHiddenLayers() + 2; ++cLayerCounter)
 						{

--- a/Backend/Machine Learning/Networks/network.h
+++ b/Backend/Machine Learning/Networks/network.h
@@ -80,11 +80,15 @@ private:
 	int minibatchSize;
 	int64_t id;
 
+	bool firstRunActivation;
+
 	// for tables & graphs
 	shmea::GList learningCurve;
 	std::vector<Point2*> rocCurve;
 	shmea::GList results;
 	shmea::GTable nbRecord;
+	//Only for sending on the network
+	shmea::GList cNodeActivations;
 
 	void SGDHelper(unsigned int, int); // Stochastic Gradient Descent
 

--- a/Backend/Machine Learning/State/LayerBuilder.cpp
+++ b/Backend/Machine Learning/State/LayerBuilder.cpp
@@ -360,6 +360,28 @@ float glades::LayerBuilder::getTimeState(unsigned int cLayerCounter, unsigned in
 	return timeState[cLayerCounter][cNodeCounter][cEdgeCounter];
 }
 
+shmea::GList glades::LayerBuilder::getWeights()
+{
+   shmea::GList weights; 
+   //We start with 1 because the first layer (input layer) doesn't have the data of the weights
+    for(unsigned int i = 0; i < getLayersSize(); ++i)
+    {
+	std::vector<Node*> cChildren = layers[i]->getChildren();
+	for(unsigned int j = 0; j < cChildren.size(); ++j)
+	{
+	   for(unsigned int k = 0; k < cChildren[j]->numEdges(); ++k)
+	   {
+		float cWeight = cChildren[j]->getEdgeWeight(k);
+		weights.addFloat(cWeight);
+	   }
+	   weights.addString(',');
+	}
+	weights.addString(';');
+    }
+
+    return weights;
+}
+
 void glades::LayerBuilder::standardizeWeights(const NNInfo* skeleton)
 {
 	// Structure required!

--- a/Backend/Machine Learning/State/LayerBuilder.h
+++ b/Backend/Machine Learning/State/LayerBuilder.h
@@ -72,6 +72,10 @@ public:
 	void print(const NNInfo*, bool = false) const;
 	void clean();
 
+	// Getters
+	shmea::GList getWeights();
+	shmea::GList getActivations();
+
 	// Database
 	bool load(const std::string&);
 	bool save(const std::string&) const;


### PR DESCRIPTION
updated network and layerbuilder so that the backend can send the activations and weights to the front end. Activations for each node is seperated by comma for each layer, while the weights are seperated by comma for each node, and semicolon for each layer. Formatting it this way makes it easier for the frontend to know what values go where.

Goes alongside with:

- Gattic/gfxplusplus:neural-network-viz
- Gattic/NNCreator:neural-network-viz